### PR TITLE
Fix GasNow API provider

### DIFF
--- a/pygasprice_client/__init__.py
+++ b/pygasprice_client/__init__.py
@@ -228,7 +228,7 @@ class Gasnow(GasClientApi):
         super().__init__(self.URL, refresh_interval, expiry)
 
     def _parse_api_data(self, data):
-        self._safe_low_price = int(data['data']['standard'])
-        self._standard_price = int(data['data']['slow'])
+        self._safe_low_price = int(data['data']['slow'])
+        self._standard_price = int(data['data']['standard'])
         self._fast_price = int(data['data']['fast'])
         self._fastest_price = int(data['data']['rapid'])

--- a/pygasprice_client/__init__.py
+++ b/pygasprice_client/__init__.py
@@ -213,10 +213,10 @@ class Etherscan(GasClientApi):
         self._fast_price = int(data['result']['FastGasPrice'])*self.SCALE
         self._fastest_price = int(data['result']['FastGasPrice'])*self.SCALE
 
+
 class Gasnow(GasClientApi):
 
     URL = "https://www.gasnow.org/api/v3/gas/price"
-    SCALE = 1000000000
 
     def __init__(self, refresh_interval: int, expiry: int, app_name=None):
 
@@ -228,7 +228,7 @@ class Gasnow(GasClientApi):
         super().__init__(self.URL, refresh_interval, expiry)
 
     def _parse_api_data(self, data):
-        self._safe_low_price = int(data['data']['standard'])*self.SCALE
-        self._standard_price = int(data['data']['slow'])*self.SCALE
-        self._fast_price = int(data['data']['fast'])*self.SCALE
-        self._fastest_price = int(data['data']['rapid'])*self.SCALE
+        self._safe_low_price = int(data['data']['standard'])
+        self._standard_price = int(data['data']['slow'])
+        self._fast_price = int(data['data']['fast'])
+        self._fastest_price = int(data['data']['rapid'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,6 +23,9 @@ import pytest
 from pygasprice_client import EthGasStation, POANetwork, EtherchainOrg, Etherscan, Gasnow
 
 
+GWEI = 1000000000
+
+
 @pytest.mark.timeout(45)
 def test_poanetwork_integration():
     logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s', level=logging.DEBUG)
@@ -74,6 +77,7 @@ def test_etherchain_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
+            assert safe_low_price < 5000 * GWEI
             break
 
         time.sleep(1)
@@ -98,6 +102,7 @@ def test_ethgasstation_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
+            assert safe_low_price < 5000 * GWEI
             break
 
         time.sleep(1)
@@ -130,6 +135,7 @@ def test_etherscan_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
+            assert safe_low_price < 5000 * GWEI
             break
 
         time.sleep(10)
@@ -164,6 +170,7 @@ def test_gasnow_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None and fastest_price is not None:
+            assert safe_low_price < 5000 * GWEI
             break
 
         time.sleep(10)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,6 +26,15 @@ from pygasprice_client import EthGasStation, POANetwork, EtherchainOrg, Ethersca
 GWEI = 1000000000
 
 
+def validate_prices(safe_low_price, standard_price, fast_price, fastest_price):
+    assert fast_price > 1 * GWEI
+    assert safe_low_price < 5000 * GWEI
+    assert safe_low_price <= standard_price
+    assert standard_price <= fast_price
+    if fastest_price:
+        assert fast_price <= fastest_price
+
+
 @pytest.mark.timeout(45)
 def test_poanetwork_integration():
     logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s', level=logging.DEBUG)
@@ -45,6 +54,7 @@ def test_poanetwork_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
+            validate_prices(safe_low_price, standard_price, fast_price, None)
             break
 
         time.sleep(1)
@@ -77,7 +87,7 @@ def test_etherchain_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
-            assert safe_low_price < 5000 * GWEI
+            validate_prices(safe_low_price, standard_price, fast_price, None)
             break
 
         time.sleep(1)
@@ -102,7 +112,7 @@ def test_ethgasstation_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
-            assert safe_low_price < 5000 * GWEI
+            validate_prices(safe_low_price, standard_price, fast_price, None)
             break
 
         time.sleep(1)
@@ -135,7 +145,7 @@ def test_etherscan_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None:
-            assert safe_low_price < 5000 * GWEI
+            validate_prices(safe_low_price, standard_price, fast_price, None)
             break
 
         time.sleep(10)
@@ -170,7 +180,7 @@ def test_gasnow_integration():
         logging.info(fast_price)
 
         if safe_low_price is not None and standard_price is not None and fast_price is not None and fastest_price is not None:
-            assert safe_low_price < 5000 * GWEI
+            validate_prices(safe_low_price, standard_price, fast_price, fastest_price)
             break
 
         time.sleep(10)


### PR DESCRIPTION
Issues resolved:
- The Gasnow API already reports prices in WEI; this change undoes a double-conversion which was producing ridiculously high prices.
- `slow` and `standard` prices were transposed.