### PR TITLE
Aggregate gas prices from all clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ the feed becomes available again.
 
 <https://chat.makerdao.com/channel/keeper>
 
+
 ## Installation
 
 This project uses *Python 3.6.6*.
@@ -19,6 +20,7 @@ git clone https://github.com/makerdao/pygasprice-client.git
 cd pygasprice-client
 pip3 install -r requirements.txt
 ```
+
 
 ## Usage
 
@@ -63,16 +65,23 @@ or with an API key (recommended)
 `gasprice_api_client = Etherscan(refresh_interval=10, expiry=600, api_key=MY_API_KEY)`
 
 #### Gasnow client
-NOTE: https://https://www.gasnow.org/ API Doc: https://https://taichi.network/  
+NOTE: https://www.gasnow.org/ API Doc: https://taichi.network/  
 Uses Spark mempool data for gas estimate.  Data is updated every 8s
-No API key is needed, but `app_name` is an optional setting.
-Requests are rate limited
+No API key is needed, but `app_name` is an optional setting.  Requests are rate limited.
 
 instantiate client as  
 `gasprice_api_client = Gasnow(refresh_interval=10, expiry=600)`  
 
 or with an App name (recommended)  
 `gasprice_api_client = Gasnow(refresh_interval=10, expiry=600, app_name="MyApp")`
+
+### Aggregation
+An _Aggregator_ client is available which combines multiple gas price sources to produce a single price.
+
+instantiate client as  
+`gasprice_agg_client = Aggregator(refresh_interval=10, expiry=600)`
+
+Arguments of component clients are also offered.  Recommend supplying API keys to avoid rate limiting.
 
 ### Retrieve gas prices
 

--- a/pygasprice_client/__init__.py
+++ b/pygasprice_client/__init__.py
@@ -76,7 +76,7 @@ class GasClientApi:
             self.logger.debug(f"Fetched current gas prices from {self.URL}: {data}")
 
             if self._expired:
-                self.logger.info(f"Current gas prices information from {self.URL} became available")
+                self.logger.info(f"Current gas prices from {self.URL} became available")
                 self._expired = False
         except:
             self.logger.warning(f"Failed to fetch current gas prices from {self.URL}")
@@ -87,11 +87,11 @@ class GasClientApi:
 
         else:
             if self._last_refresh == 0:
-                self.logger.warning(f"Current gas prices information from {self.URL} is unavailable")
+                self.logger.warning(f"Current gas prices from {self.URL} are unavailable")
                 self._last_refresh = 1
 
             if not self._expired:
-                self.logger.warning(f"Current gas prices information from {self.URL} has expired")
+                self.logger.warning(f"Current gas prices from {self.URL} have expired")
                 self._expired = True
 
             return None

--- a/pygasprice_client/aggregator.py
+++ b/pygasprice_client/aggregator.py
@@ -68,6 +68,8 @@ class Aggregator(GasClientApi):
     def aggregate_price(prices: list):
         assert isinstance(prices, list)
 
+        if len(prices) > 3:
+            prices.remove(max(prices))
         if len(prices) > 2:
             prices.remove(min(prices))
 

--- a/pygasprice_client/aggregator.py
+++ b/pygasprice_client/aggregator.py
@@ -22,26 +22,26 @@ from pygasprice_client import GasClientApi, EthGasStation, POANetwork, Etherchai
 
 class Aggregator(GasClientApi):
 
-    def __init__(self, refresh: int, expiry: int, ethgasstation_api_key=None):
+    def __init__(self, refresh_interval: int, expiry: int, ethgasstation_api_key=None, poa_network_alt_url=None,
+                 etherscan_api_key=None, gasnow_app_name="pygasprice-client"):
         self.clients = [
-            EthGasStation(refresh_interval=refresh, expiry=refresh, api_key=ethgasstation_api_key),
-            EtherchainOrg(refresh_interval=refresh, expiry=refresh),
-            POANetwork(refresh_interval=refresh, expiry=refresh),
-            Etherscan(refresh_interval=refresh, expiry=refresh),
-            Gasnow(refresh_interval=refresh, expiry=refresh)
+            EthGasStation(refresh_interval=refresh_interval, expiry=expiry, api_key=ethgasstation_api_key),
+            EtherchainOrg(refresh_interval=refresh_interval, expiry=expiry),
+            POANetwork(refresh_interval=refresh_interval, expiry=expiry, alt_url=poa_network_alt_url),
+            Etherscan(refresh_interval=refresh_interval, expiry=expiry, api_key=etherscan_api_key),
+            Gasnow(refresh_interval=refresh_interval, expiry=expiry, app_name=gasnow_app_name)
         ]
         self._safe_low_price = None
         self._standard_price = None
         self._fast_price = None
         self._fastest_price = None
 
-        super().__init__("aggregator", refresh, expiry)
+        super().__init__("aggregator", refresh_interval, expiry)
 
     def _background_run(self):
         # Wait a few seconds for data to become available
-        for wait in range(min(5, self.clients[0].refresh_interval)):
+        for wait in range(min(5, self.refresh_interval)):
             time.sleep(0.5)  # Since there's no synchronous API, wait a few seconds for data to become available
-            print("waiting for data to become available")
             any(map(lambda c: c._last_refresh > 1, self.clients))
 
         while True:

--- a/pygasprice_client/aggregator.py
+++ b/pygasprice_client/aggregator.py
@@ -1,0 +1,79 @@
+# This file is part of Maker Keeper Framework.
+#
+# Copyright (C) 2020 EdNoepel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+
+from pygasprice_client import GasClientApi, EthGasStation, POANetwork, EtherchainOrg, Etherscan, Gasnow
+
+
+class Aggregator(GasClientApi):
+
+    def __init__(self, refresh: int, expiry: int, ethgasstation_api_key=None):
+        self.clients = [
+            EthGasStation(refresh_interval=refresh, expiry=refresh, api_key=ethgasstation_api_key),
+            EtherchainOrg(refresh_interval=refresh, expiry=refresh),
+            POANetwork(refresh_interval=refresh, expiry=refresh),
+            Etherscan(refresh_interval=refresh, expiry=refresh),
+            Gasnow(refresh_interval=refresh, expiry=refresh)
+        ]
+        self._safe_low_price = None
+        self._standard_price = None
+        self._fast_price = None
+        self._fastest_price = None
+
+        super().__init__("aggregator", refresh, expiry)
+
+    def _background_run(self):
+        # Wait a few seconds for data to become available
+        for wait in range(min(5, self.clients[0].refresh_interval)):
+            time.sleep(0.5)  # Since there's no synchronous API, wait a few seconds for data to become available
+            print("waiting for data to become available")
+            any(map(lambda c: c._last_refresh > 1, self.clients))
+
+        while True:
+            self._fetch_price()
+            time.sleep(self.refresh_interval)
+
+    def _fetch_price(self):
+        # map() checks the client's price, filter() cleanses "None" prices from the list
+        safe_low_prices = list(filter(lambda p: p, map(lambda c: c.safe_low_price(), self.clients)))
+        standard_prices = list(filter(lambda p: p, map(lambda c: c.standard_price(), self.clients)))
+        fast_prices = list(filter(lambda p: p, map(lambda c: c.fast_price(), self.clients)))
+        fastest_prices = list(filter(lambda p: p, map(lambda c: c.fastest_price(), self.clients)))
+
+        self._safe_low_price = self.aggregate_price(safe_low_prices)
+        self._standard_price = self.aggregate_price(standard_prices)
+        self._fast_price = self.aggregate_price(fast_prices)
+        self._fastest_price = self.aggregate_price(fastest_prices)
+
+        self.logger.debug(f"Aggregated {fast_prices} to {self._fast_price}")
+
+        self._last_refresh = int(time.time())
+
+    @staticmethod
+    def aggregate_price(prices: list):
+        assert isinstance(prices, list)
+
+        if len(prices) > 2:
+            prices.remove(min(prices))
+
+        if len(prices) > 1:
+            return sum(prices) / len(prices)
+        elif len(prices) > 0:
+            return prices[0]
+        else:
+            return None

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0',  # Required
+    version='1.1',  # Required
     description='Python API for retrieving gas prices',
     license='COPYING',
     long_description=long_description,

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -40,10 +40,20 @@ def test_aggregator():
 def test_aggregation_methodology():
     GWEI = 1000000000
 
-    # A normal use case
+    # A normal use case with an outlier
+    prices = [24.00 * GWEI, 15.00 * GWEI, 24.00 * GWEI, 127.00 * GWEI, 13.00 * GWEI]
+    price = Aggregator.aggregate_price(prices)
+    assert price == 21.0 * GWEI
+
+    # One price missing
     prices = [64.0 * GWEI, 64.0 * GWEI, 72.0 * GWEI, 65.0 * GWEI]
     price = Aggregator.aggregate_price(prices)
-    assert price == 67 * GWEI
+    assert price == 64.5 * GWEI
+
+    # Only three prices
+    prices = [16.80 * GWEI, 18.00 * GWEI, 15.65 * GWEI]
+    price = Aggregator.aggregate_price(prices)
+    assert price == 17.4 * GWEI
 
     # Only two prices
     prices = [23.0 * GWEI, 24.0 * GWEI]

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,0 +1,61 @@
+# This file is part of Maker Keeper Framework.
+#
+# Copyright (C) 2020 EdNoepel
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import time
+
+from pygasprice_client.aggregator import Aggregator
+
+
+@pytest.mark.timeout(15)
+def test_aggregator():
+    aggregator = Aggregator(10, 600)
+
+    time.sleep(3)  # Since there's no synchronous API, wait a few seconds for data to become available
+
+    assert aggregator.safe_low_price()
+    assert aggregator.standard_price()
+    assert aggregator.fast_price()
+    assert aggregator.fastest_price()
+
+    assert aggregator.safe_low_price() <= aggregator.standard_price()
+    assert aggregator.standard_price() <= aggregator.fast_price()
+    assert aggregator.fast_price() <= aggregator.fastest_price()
+
+
+def test_aggregation_methodology():
+    GWEI = 1000000000
+
+    # A normal use case
+    prices = [64.0 * GWEI, 64.0 * GWEI, 72.0 * GWEI, 65.0 * GWEI]
+    price = Aggregator.aggregate_price(prices)
+    assert price == 67 * GWEI
+
+    # Only two prices
+    prices = [23.0 * GWEI, 24.0 * GWEI]
+    price = Aggregator.aggregate_price(prices)
+    assert price == 23.5 * GWEI
+
+    # One price
+    prices = [33.3 * GWEI]
+    price = Aggregator.aggregate_price(prices)
+    assert price == 33.3 * GWEI
+
+    # No prices should return None, not throw
+    prices = []
+    price = Aggregator.aggregate_price(prices)
+    assert not price

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -158,6 +158,7 @@ def test_etherscan_url():
     etherscan = Etherscan(10, 600, "abcdefg")
     assert etherscan.URL == "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=abcdefg"
 
+
 @pytest.mark.timeout(45)
 def test_gasnow_integration():
     logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s', level=logging.DEBUG)


### PR DESCRIPTION
Adds another gas api client which aggregates all the others into a single price.  Unit tests have 100% coverage of the new code. 
 Updated README accordingly.